### PR TITLE
Changing the max aggregate size for a single node system in Azure to 200 TB

### DIFF
--- a/reference_limits_azure_96.adoc
+++ b/reference_limits_azure_96.adoc
@@ -89,7 +89,7 @@ Cloud Volumes ONTAP uses Azure storage as disks and groups them into _aggregates
 
 | Maximum number of aggregates | Same as the disk limit
 | Maximum aggregate size |
-352 TB of raw capacity for single node ^1^
+200 TB of raw capacity for single node ^1^
 96 TB of raw capacity for HA pairs ^1^
 | Disks per aggregate	| 1-12 ^2^
 | Maximum number of RAID groups per aggregate	| 1

--- a/reference_storage_limits_93.adoc
+++ b/reference_storage_limits_93.adoc
@@ -54,7 +54,7 @@ Notes:
 
 .5+| *Aggregates and disks*
 | Maximum number of aggregates | 63
-| Maximum aggregate size |	352 TB of raw capacity
+| Maximum aggregate size |	200 TB of raw capacity
 | Disks per aggregate	| 1-12 ^1^
 | Maximum disk size | 32 TB
 | Maximum number of data disks across all aggregates ^2^ a|

--- a/reference_storage_limits_94.adoc
+++ b/reference_storage_limits_94.adoc
@@ -82,7 +82,7 @@ Notes:
 
 .5+| *Aggregates and disks*
 | Maximum number of aggregates | Same as the disk limit
-| Maximum aggregate size |	352 TB of raw capacity ^1^
+| Maximum aggregate size |	200 TB of raw capacity ^1^
 | Disks per aggregate	| 1-12 ^2^
 | Maximum disk size | 32 TB
 | Maximum number of data disks across all aggregates ^3^ | Depends on VM size. <<Capacity and disk limits by Azure VM size,See below>>.

--- a/reference_storage_limits_95.adoc
+++ b/reference_storage_limits_95.adoc
@@ -180,7 +180,7 @@ Cloud Volumes ONTAP uses Azure storage as disks and groups them into _aggregates
 
 | Maximum number of aggregates | Same as the disk limit
 | Maximum aggregate size |
-352 TB of raw capacity for single node ^1^
+200 TB of raw capacity for single node ^1^
 96 TB of raw capacity for HA pairs ^1^
 | Disks per aggregate	| 1-12 ^2^
 | Maximum number of RAID groups per aggregate	| 1


### PR DESCRIPTION
The aggregate limit for a single node system in Azure was documented as 352 TB. However, Cloud Volumes ONTAP supports up to 200 TB in a single aggregate.